### PR TITLE
Update en.po

### DIFF
--- a/backend/locale/en.po
+++ b/backend/locale/en.po
@@ -202,7 +202,7 @@ msgid "linux-knowledge-question"
 msgstr "How would you rate your knowledge of Linux itself?"
 
 msgid "linux-knowledge-answer-beginner"
-msgstr "I do not have any or just little knowledge about Linux"
+msgstr "I have little or no knowledge about Linux"
 
 msgid "linux-knowledge-answer-advanced"
 msgstr "I have already used Linux for some purposes"


### PR DESCRIPTION
Change the text of the `linux-knowledge-answer-beginner` message to more idiomatic English.

This was proposed and agreed [here](https://github.com/distrochooser/distrochooser/pull/72#discussion_r330471635).