### PR TITLE
Updates for #259

### DIFF
--- a/viisi/components/categories.vue
+++ b/viisi/components/categories.vue
@@ -1,27 +1,58 @@
 <template lang="pug">
-    div.breadcrumb-horizontal
-      ul
-        li
-          a(href="#",@click="restart",:class="{'active': isAtWelcomeScreen && !isAtHardwareScreen,'inactive': !isAtWelcomeScreen  }") 
-            i.active-indicator.w-icon-login
-            span {{ __i("category-welcome") }}
-        li
-          a(href="#",@click="openHardwareScreen",:class="{'active': isAtHardwareScreen,'inactive': !isAtHardwareScreen, 'answered': $store.state.hardwareRequirements != null }") 
-            i.active-indicator.w-icon-laptop
-            span {{ __i("category-hardware-requirements") }}
-        li(v-for="(category, c_k) in categories" v-bind:key="c_k", )
-          a(href="#", @click="selectCategory(category)")
-            i.active-indicator(:class="category.iconClass + (isAnswered(category) ? ' mobile-answered' : '') + (isActive(category) ? ' mobile-active' : '') + (isMarked(category) ? ' mobile-marked' : '')")
-            span(:class="{'active': isActive(category), 'inactive': !isActive(category), 'mobile-answered': isAnswered(category)}") {{ __i(category.msgid) }}
-            i.w-icon-save.marked(v-if="isMarked(category)",:title="__i('marked')")
-        li(v-if="$store.state.visuallyImpairedMode")
-          a(href="#", class="recommendation-link", :aria-disabled="$store.state.givenAnswers.length === 0", @click.prevent="submit", :title="__i('recommendation-category')") {{ __i("recommendation-category") }}
+.breadcrumb-horizontal
+  ul
+    li
+      a(
+        href='#',
+        @click='restart',
+        :class='{ active: isAtWelcomeScreen && !isAtHardwareScreen, inactive: !isAtWelcomeScreen }'
+      ) 
+        |
+        i.active-indicator.w-icon-login
+        span {{ __i('category-welcome') }}
+    li(:title='__i("category-hardware-requirements")')
+      a(
+        href='#',
+        @click='openHardwareScreen',
+        :class='{ active: isAtHardwareScreen, inactive: !isAtHardwareScreen, answered: $store.state.hardwareRequirements != null }'
+      ) 
+        |
+        i.active-indicator.w-icon-laptop
+        span {{ __i('category-hardware-requirements') }}
+    li(
+      v-for='(category, c_k) in categories',
+      v-bind:key='c_k',
+      :title='__i(category.msgid)'
+    )
+      a(href='#', @click='selectCategory(category)')
+        i.active-indicator(
+          :class='category.iconClass + (isAnswered(category) ? " mobile-answered" : "") + (isActive(category) ? " mobile-active" : "") + (isMarked(category) ? " mobile-marked" : "")'
+        )
+        span(
+          :class='{ active: isActive(category), inactive: !isActive(category), "mobile-answered": isAnswered(category) }'
+        ) {{ __i(category.msgid) }}
+        i.w-icon-save.marked(v-if='isMarked(category)', :title='__i("marked")')
+    li(
+      v-if='$store.state.visuallyImpairedMode',
+      :title='__i("recommendation-category")'
+    )
+      a.recommendation-link(
+        href='#',
+        :aria-disabled='$store.state.givenAnswers.length === 0',
+        @click.prevent='submit',
+        :title='__i("recommendation-category")'
+      ) {{ __i('recommendation-category') }}
 
-
-      div.floating-button(v-if="!$store.state.visuallyImpairedMode", :title="__i('recommendation-category')", :class="{'disabled': $store.state.givenAnswers.length === 0}",:data-balloon="__i($store.state.givenAnswers.length === 0 ? 'no-answers' : 'get-my-result')",data-balloon-pos="right",@click.prevent="submit")
-        i.w-icon-right-square-o
-        span {{ __i("recommendation-category") }}
-        
+  .floating-button(
+    v-if='!$store.state.visuallyImpairedMode',
+    :title='__i("recommendation-category")',
+    :class='{ disabled: $store.state.givenAnswers.length === 0 }',
+    :data-balloon='__i($store.state.givenAnswers.length === 0 ? "no-answers" : "get-my-result")',
+    data-balloon-pos='right',
+    @click.prevent='submit'
+  )
+    i.w-icon-right-square-o
+    span {{ __i('recommendation-category') }}
 </template>
 
 <script>
@@ -32,8 +63,8 @@ export default {
     language: {
       type: String,
       required: true,
-      default: 'en'
-    }
+      default: 'en',
+    },
   },
   computed: {
     isLoaded() {
@@ -46,22 +77,25 @@ export default {
       return !this.$store.state.isStarted
     },
     isAtHardwareScreen() {
-      return this.$store.state.isAtHardwareScreen && this.$store.state.result === null
-    }
+      return (
+        this.$store.state.isAtHardwareScreen &&
+        this.$store.state.result === null
+      )
+    },
   },
   methods: {
     openHardwareScreen() {
-      this.$store.commit("setStarted")
-      
+      this.$store.commit('setStarted')
+
       this.$store.commit('resetResult')
-      this.$store.commit("openHardwareScreen")
+      this.$store.commit('openHardwareScreen')
     },
     closeHardwareScreen() {
-      this.$store.commit("closeHardwareScreen")
+      this.$store.commit('closeHardwareScreen')
     },
     isAnswered(category) {
       return (
-        this.$store.state.givenAnswers.filter(function(a) {
+        this.$store.state.givenAnswers.filter(function (a) {
           return a.category === category.msgid
         }).length > 0
       )
@@ -70,21 +104,21 @@ export default {
       return (
         this.$store.state.result === null &&
         this.$store.state.currentCategory !== null &&
-        this.$store.state.currentCategory.msgid === category.msgid && 
+        this.$store.state.currentCategory.msgid === category.msgid &&
         !this.$store.state.isAtHardwareScreen
       )
     },
     isMarked(category) {
-      if (!category){
-        return false;
+      if (!category) {
+        return false
       }
-      return this.$store.state.markedQuestions.indexOf(category.msgid) !== -1      
+      return this.$store.state.markedQuestions.indexOf(category.msgid) !== -1
     },
     selectCategory(category) {
       const _t = this
       this.$store.dispatch('selectCategory', {
         language: _t.language,
-        selectedCategory: category
+        selectedCategory: category,
       })
     },
     restart() {
@@ -95,8 +129,8 @@ export default {
       var _t = this
       this.$store.dispatch('nextQuestion', {
         params: {
-          language: _t.language
-        }
+          language: _t.language,
+        },
       })
     },
     submit() {
@@ -114,14 +148,14 @@ export default {
         params: {
           token: this.$store.state.token,
           language: this.language,
-          method: this.$store.state.method
+          method: this.$store.state.method,
         },
         data: {
-          answers: this.$store.state.givenAnswers
-        }
+          answers: this.$store.state.givenAnswers,
+        },
       })
-    }
-  }
+    },
+  },
 }
 </script>
 <style lang="scss" scoped>
@@ -133,7 +167,11 @@ export default {
   left: 1em;
   font-family: Archivo;
   letter-spacing: 0.5px;
-  padding-top: 1em;
+  top: 0px;
+  padding-top: 5%;
+  border-right: 1px solid #89898966;
+  height: 100%;
+  padding-right: 2.5em;
 }
 .breadcrumb-horizontal ul {
   list-style-type: none;
@@ -186,18 +224,18 @@ export default {
   margin-left: 1.6em;
   background: $linkColor;
   padding: 1em;
-  color: white;
+  color: white !important;
 }
 .floating-button a {
   text-decoration: none;
-  color: white;
+  color: white !important;
 }
 .floating-button a i {
   vertical-align: bottom;
 }
 .disabled {
   cursor: no-drop;
-  background: white;
+  background: white !important;
   color: black;
   border: 1px solid black;
 }

--- a/viisi/components/distribution.vue
+++ b/viisi/components/distribution.vue
@@ -434,7 +434,7 @@ i {
   text-align: right;
   margin-bottom: 0.5em;
   margin-top: -0.5em;
-  color: #d9d9d9;
+  color: #999696;
   margin-right: 1em;
   font-size: 10pt;
 }

--- a/viisi/components/hardware.vue
+++ b/viisi/components/hardware.vue
@@ -28,7 +28,7 @@
                 input(name="cpu-cores", type="number", :placeholder="__i('hardware-cpu-cores-placeholder')", v-model="cpuCores")
             div.cpu.hardware-input.frequency
                 label(for="cpu-frequency") {{  __i('hardware-cpu-frequency-title') }}
-                input(name="cpu-frequency", :placeholder="__i('hardware-cpu-frequency-placeholder')",v-model="cpuFrequency")
+                input(name="cpu-frequency",  type="number", :placeholder="__i('hardware-cpu-frequency-placeholder')",v-model="cpuFrequency")
             div.memory.hardware-input
                 label(for="memory") {{  __i('hardware-memory-title') }}
                 input(name="memory", type="number", :placeholder="__i('hardware-memory-placeholder')", v-model="memory")
@@ -171,6 +171,9 @@ mixins: [i18n],
     input,
     i {
         display: table-cell;
+    }
+    input[type='number'] {
+        min-width: 20%;
     }
 }
 code {

--- a/viisi/components/question.vue
+++ b/viisi/components/question.vue
@@ -319,6 +319,7 @@ export default {
   width: 80%;
   margin-right: 10%;
   margin-left: 10%;
+  animation: fadeIn 0.5s;
 }
 @media only screen and (max-width: $mobileWidth) {
   .question {

--- a/viisi/components/result.vue
+++ b/viisi/components/result.vue
@@ -180,6 +180,7 @@ export default {
   margin-left: 15%;
   height: 25em;
   font-family: 'Open Sans', sans-serif;
+  animation: fadeIn 0.5s;
 }
 .compact-result {
   .compact-distribution {

--- a/viisi/pages/_language/_slug.vue
+++ b/viisi/pages/_language/_slug.vue
@@ -7,13 +7,13 @@
         img.top-logo(src='/logo.min.svg', alt="Distrochooser.de Logo")
     div.calculation-loading(v-if="isLoading || $store.state.isSubmitted") 
       div.spinner(v-if="!$store.state.visuallyImpairedMode")
-      div.spinner-text(v-else) {{ __i("loading") }}
-    categories(:language="language",v-if="!isLoading && !$store.state.isSubmitted")
+      div.spinner-text {{ __i("loading") }}
+    categories(:language="language",class="loading-hidden", v-bind:class="{'loading-show': !isLoading && !$store.state.isSubmitted}")
     div(v-if="!isLoading && !isFinished && !$store.state.isSubmitted")
       question(:language="language")
     div(v-if="!isLoading && isFinished&& !$store.state.isSubmitted")
       result(:language="language")
-    div.language-select(v-if="!$store.state.isStarted")
+    div.language-select(v-if="!$store.state.isStarted && !$store.state.isAtHardwareScreen")
       label(for="language") {{ __i("language") }}
       select(v-if="!isLoading", v-model="language",id="language",:title="__i('language')")
         option(v-for="(locale, locale_key) in $store.state.locales", :key="locale_key", v-bind:value="locale_key") {{locale}}
@@ -321,7 +321,7 @@ export default {
   width: 100%;
   padding: 1em;
   background: red;
-  z-index: -10000000;
+  z-index: 10000000;
   color: white;
   a {
     color: white;
@@ -351,16 +351,35 @@ select::-ms-expand {
   }
 }
 .calculation-loading {
-  text-align: center;
-  margin-top: 15%;
+  z-index: 1100000;
+}
+.calculation-loading,
+.spinner-text {
   font-size: large;
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 100%;
+  height: 100%;
+  animation: fadeIn 1s;
+}
+.spinner-text{
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: auto;
+  text-align: center;
+  padding-top: 7em;
 }
 .calculation-text {
   padding-top: 2em;
 }
 
 .spinner {
-  display: inline-block;
   width: 100px;
   height: 100px;
   border: 5px solid lightgray;
@@ -368,9 +387,14 @@ select::-ms-expand {
   border-top-color: $spinColor;
   animation: spin 1s infinite;
   -webkit-animation: spin 1s infinite;
-  margin: 100px auto;
-  text-align: center;
+  margin: 0 auto;
   font-size: 10px;
+  position: absolute;  
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: auto;
 }
 
 @keyframes spin {
@@ -573,5 +597,11 @@ select::-ms-expand {
     text-align: left;
     margin-right: 1.5em;
   }
+}
+.loading-show{
+  display: initial !important;
+}
+.loading-hidden{
+  display: none;
 }
 </style>

--- a/viisi/scss/mobile.scss
+++ b/viisi/scss/mobile.scss
@@ -23,6 +23,7 @@
     width: auto;
     padding: 0px !important;
     top: 1em !important;
+    padding-right: 0.5em !important;
     ul li span {
       display: none;
     }
@@ -185,8 +186,9 @@
     overflow-y: scroll;
     max-height: 100%;
     overflow-x: hidden;
-    padding-right: 2em;
-    padding-top: unset !important;
+    padding-right: 0.6em !important;
+    padding-top: 20% !important;
+    top: 0px !important;
 
     .floating-button {
       span {

--- a/viisi/scss/variables.scss
+++ b/viisi/scss/variables.scss
@@ -1,5 +1,5 @@
-$mobileWidth: "1200px";
-$desktopMinWidth: "1200px";
+$mobileWidth: "1500px";
+$desktopMinWidth: "1500px";
 $desktopWidth: "1400px";
 
 //Colors
@@ -44,5 +44,12 @@ $inactiveDarkFont: rgb(178, 176, 176);
 i{
   vertical-align: top;
 }
+
+@keyframes fadeIn {
+  0% { opacity: 0.5; }
+  100% { opacity: 1; }
+}
+
 @import "mobile.scss";
 @import "dark.scss";
+@import "displaymodes.scss";


### PR DESCRIPTION
- Add optical separator between main navigation and page content
- Update mobile breakpoints to avoid overflow
- Increase contrast for metrics source link
- Avoid the navigation from flash in
- Avoid the result list from flashing in
- Unset all animations (if any)
- Reduce opacity of loading spinner