### PR TITLE
feat 1: add security.txt in distrochooser

### DIFF
--- a/security.txt
+++ b/security.txt
@@ -1,0 +1,7 @@
+Contact: mailto: mail@chmr.eu
+Expires: 2027-12-25T15:12:00.000Z
+Preferred-Languages: en, fr, de
+Policy: https://distrochooser.de/info/privacy/en
+Policy: https://github.com/distrochooser/distrochooser/blob/master/SECURITY.md
+Policy: https://github.com/distrochooser/distrochooser/blob/master/LICENSE
+Policy: https://github.com/distrochooser/distrochooser/blob/master/README.md


### PR DESCRIPTION
Hi cmllr, how are you?

I added the [security.txt](https://securitytxt.org/) file in the distrochooser project. Please, accept this pull-request and include the [security.txt](https://github.com/securitytxt/security-txt) file in the distrochooser project. With security.txt, anyone can easily get in touch about security issues. For example, please see this:

![image](https://github.com/distrochooser/distrochooser/assets/132034879/145b926e-462d-4e6b-a53c-4edfcac2240d)

distrochooser is an open and online project, an website to facilitate the choice of linux distribution for common users. In that sense, there's a good reason to include the security.txt file in case someone finds a security flaw on the site. So, I would be happy to contribute to this initially.

This is my first pull-request and I hope you all like the idea of ​​a security.txt file to make it easier to report security flaws to distrochooser.