### PR TITLE
Fix size of age filter and result link on xxl screens

### DIFF
--- a/code/kuusi/web/templates/widgets/result_list.html
+++ b/code/kuusi/web/templates/widgets/result_list.html
@@ -1,9 +1,9 @@
 {% load web_extras %}
 <div id="result-filter-collapse" class="row">
-    <div class="col-4 col-xl-2 col-xxl-4">
+    <div class="col-4 col-xl-2 col-xxl-2">
 
     </div>
-    <div class="col-12 col-xl-8 col-xxl-4">
+    <div class="col-12 col-xl-8 col-xxl-8">
         <div class="card card-body mt-3">
             <div class="row">
                 {% for filter_group, filters in all_filters.items %}

--- a/code/kuusi/web/templates/widgets/result_list.html
+++ b/code/kuusi/web/templates/widgets/result_list.html
@@ -11,7 +11,7 @@
                     <div class="col-12 text-center mb-3">
                         <form>
                             <label for="ku-age-filter" class="form-label d-block">{% _i18n_ language_code filter_group %}</label>
-                            <div class="btn-group" role="group" id=""ku-age-filter">
+                            <div class="btn-group" role="group" id="ku-age-filter">
                                 {% for filter_key, filter_active in filters.items %}
                                     <a href="?page=result-page&toggle_filter={{filter_key}}{% if filter_key  in active_filters%}&disable_filter=true{% endif%}" class="btn btn-outline-primary {% if filter_key  in active_filters%}active{% endif%}"> 
                                         {% if filter_key  in active_filters%}

--- a/code/kuusi/web/templates/widgets/result_share.html
+++ b/code/kuusi/web/templates/widgets/result_share.html
@@ -38,10 +38,10 @@
     </div>
 </div>
 <div class="row">
-    <div class="col-4 col-xl-2 col-xxl-4">
+    <div class="col-4 col-xl-2 col-xxl-2">
 
     </div>
-    <div class="col-12 col-xl-8 col-xxl-4">
+    <div class="col-12 col-xl-8 col-xxl-8">
         <div class="input-group">
             <span class="input-group-text" id="result-link-number"><i class="bi bi-paperclip"></i></span>
             <input type="text" class="form-control share-link" id="result-link"


### PR DESCRIPTION
The div boxes for the age filter and result link uses `col-xxl-4` for xxl screens, which results in too little space for the content. This PR is a simple fix to adjust the size. Here's the comparison on a 1920x1080 viewpoint:

| **Before** |
| ---------- |
| ![before](https://github.com/user-attachments/assets/6696f1bb-74bf-4b9e-9684-fddaba2e6ae3) |

| **After**  |
|------------|
| ![after](https://github.com/user-attachments/assets/db5a32a2-a930-448c-ae00-e427271f1922) |




Also removed an unnecessary quotation mark :)