### PR TITLE
Fix server error caused by incomplete meta_tags translation (Issue #331)

### DIFF
--- a/code/kuusi/web/templatetags/web_extras.py
+++ b/code/kuusi/web/templatetags/web_extras.py
@@ -32,6 +32,10 @@ from web.models.sessionversion import A11Y_OPTIONS_BODYCLASSES
 from web.forms import WarningForm
 from kuusi.settings import KUUSI_COPYRIGHT_STRING, KUUSI_INFO_STRING, LANGUAGE_CODES, KUUSI_META_TAGS, DEFAULT_LANGUAGE_CODE
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 register = template.Library()
 
 @register.filter
@@ -226,11 +230,14 @@ def rtl_class(language_code: str):
     return "ku-rtl" if  language_code in RTL_TRANSLATIONS else "ku-ltr"
 
 @register.inclusion_tag(filename="tags/meta_tags.html")
-def meta_tags(language_code:str, page: Page, session: Session):
+def meta_tags(language_code: str, page: Page, session: Session):
     result = KUUSI_META_TAGS
     for key, _ in result.items():
         if "description" in key:
-            result[key] = strip_tags(TRANSLATIONS[language_code]["DESCRIPTION_TEXT"])
+            if "DESCRIPTION_TEXT" in TRANSLATIONS[language_code]:
+                result[key] = strip_tags(TRANSLATIONS[language_code]["DESCRIPTION_TEXT"])
+            else:
+                logger.warning(f'DESCRIPTION_TEXT missing for language: {language_code}')
     return {
         "tags": result
     }


### PR DESCRIPTION
**Solution:**

- Added a check to ensure that the `DESCRIPTION_TEXT` key is present in the currently active translation.
- If the key is missing, the code safely skips the update, preventing the server from throwing an error.

**Testing:**
- Tested with translations that include `DESCRIPTION_TEXT` and those that don't.
- Verified that no server errors occur in either case, and the application handles missing translations gracefully.