### PR TITLE
fix: correct typos in CONCEPTS.md, support.html, and CONTRIBUTING.md

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -84,7 +84,7 @@ If additional class names are being introduced, the class prefix `ku-` should be
 }
 ```
 
-The SCSS files are embeeded in a `/design/scss/custom.scss` file, which brings the Bootstrap 5 and Distrochooser theme parts together.
+The SCSS files are embedded in a `/design/scss/custom.scss` file, which brings the Bootstrap 5 and Distrochooser theme parts together.
 
 To get these file compiled/ picked up by the webserver, the script `build-styles` is available inside the `/design/package.json`. Important: **Please execute this scripts from the folder `/design`, as the `build-styles` script uses relative paths.**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to the distrochooser project 🎉!
 
 Distrochooser has a very slow development cycle as this is a "weekend warrior" project. This means that issues might be unanswered for months before being picked up. But don't worry, they will be discussed, but just not that fast as in large projects. 
 
-Please note that there will no discussions with deleted accounts (on PR/ Issues/ Discussions). These threads will be closed.
+Please note that there will be no discussions with deleted accounts (on PR/ Issues/ Discussions). These threads will be closed.
 
 > Please inform me when you plan to contribute (e. g. in the discussion tab or in an issue), so I can introduce you to caveats/issues and give you hints on how to realize your contribution in the best possible way. Thank you!
 

--- a/code/kuusi/web/templates/support.html
+++ b/code/kuusi/web/templates/support.html
@@ -6,7 +6,7 @@
 {%block logo%}{% logo language_code True %}{%endblock%}
 {% block container-class %}container{% endblock %}
 {% block content%}
-<div classs="row">
+<div class="row">
     <div class="col-12">
         <h1>{% _i18n_ language_code "LINK_SUPPORT" %}</h1>
         <p>


### PR DESCRIPTION
Fixed typos in documentation and template files:

- "embeeded" -> "embedded" in `CONCEPTS.md`
- "classs" -> "class" in `support.html`
- "there will no discussions" -> "there will be no discussions" in `CONTRIBUTING.md`