### PR TITLE
Frontend implementation

### DIFF
--- a/code/frontend/components/Language.vue
+++ b/code/frontend/components/Language.vue
@@ -9,6 +9,7 @@
     </div>
 </template>
 <script setup lang="ts">
+import { watch } from 'vue';
 import { useSessionStore } from '../states/session';
 
 

--- a/code/frontend/components/widgets/FacetteSelectionWidget.vue
+++ b/code/frontend/components/widgets/FacetteSelectionWidget.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     {{ props.widget.facettes  }}
+    <Behaviour v-for="(facette, index) in props.widget.facettes" v-bind:key="index"  :facette="facette"/>
     <div v-for="(facette, index) in props.widget.facettes" v-bind:key="index">
       <Facette :facette="facette" :checkbox="props.checkbox"/>
     </div>
@@ -12,6 +13,7 @@ import { onMounted } from "vue";
 import { SessionApi, type FacetteSelectionWidget } from "~/sdk";
 import { apiConfig, useSessionStore } from "~/states/session";
 import Facette from "./facettes/Facette.vue";
+import Behaviour from "./facettes/Behaviour.vue";
 
 interface WidgetProps {
   widget: FacetteSelectionWidget;

--- a/code/frontend/components/widgets/RankedChoosable.vue
+++ b/code/frontend/components/widgets/RankedChoosable.vue
@@ -1,11 +1,12 @@
 <template>
     <div>
         {{ props.choosable.name }}
-        {{ props.choosable.meta }}
+        <ChoosableMeta v-for="(key, value, index) in props.choosable.meta" :key="index" :metaKey="key" :metaValue="value"/>
     </div>
 </template>
 <script setup lang="ts">
 import type {  RankedChoosable } from '~/sdk';
+import ChoosableMeta from './rankedchoosable/ChoosableMeta.vue';
 interface WidgetProps {
   choosable: RankedChoosable;
 }

--- a/code/frontend/components/widgets/facettes/Behaviour.vue
+++ b/code/frontend/components/widgets/facettes/Behaviour.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>{{ behaviours }}</div>
+</template>
+<script setup lang="ts">
+import type { Facette } from "~/sdk";
+import { useSessionStore } from "../../../states/session";
+
+interface BehaviourProps {
+  facette: Facette;
+}
+
+const props = defineProps<BehaviourProps>();
+const store = useSessionStore();
+const behaviours = computed((b) =>
+  store.facetteBehaviours.filter(
+    (fb) =>
+      fb.affectedObjects.filter((ao) => ao == props.facette.id).length > 0 ||
+      fb.affectedSubjects.filter((ao) => ao == props.facette.id).length > 0
+  )
+);
+</script>

--- a/code/frontend/components/widgets/facettes/Facette.vue
+++ b/code/frontend/components/widgets/facettes/Facette.vue
@@ -57,6 +57,7 @@ const registerChange = async () => {
   if (!selected.value) {
     weight.value = 0
   }
+  await store.updateBehaviours();
 };
 const registerWeightChange = async() => {
   await store.updateFacetteSelections(store.currentPage.id, props.facette.id, weight.value, selected.value, 'this');

--- a/code/frontend/components/widgets/rankedchoosable/ChoosableMeta.vue
+++ b/code/frontend/components/widgets/rankedchoosable/ChoosableMeta.vue
@@ -1,0 +1,14 @@
+<template>
+    <div>
+        {{  metaKey }}: {{metaValue}}
+    </div>
+</template>
+<script setup lang="ts">
+
+interface WidgetProps {
+  metaKey: String;
+  metaValue: String
+}
+
+const props = defineProps<WidgetProps>();
+</script>

--- a/code/frontend/states/session.ts
+++ b/code/frontend/states/session.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { Configuration, SessionApi, type Category, type Facette, type FacetteSelection, type InitialSession, type MetaWidget, type Page, type Session, type Widget } from "~/sdk"
+import { Configuration, SessionApi, type Category, type Facette, type FacetteBehaviour, type FacetteSelection, type InitialSession, type MetaWidget, type Page, type Session, type Widget } from "~/sdk"
 
 interface SessionState {
     session: Session | null;
@@ -8,7 +8,8 @@ interface SessionState {
     currentPage: Page | null;
     facetteSelections: FacetteSelection[];
     currentWidgets: MetaWidget[];
-    answeredPages: number[]
+    answeredPages: number[],
+    facetteBehaviours: FacetteBehaviour[]
 }
 
 // TODO: Move this out of this sourcecode
@@ -28,7 +29,8 @@ export const useSessionStore = defineStore('websiteStore', {
         currentPage: null,
         facetteSelections: [],
         currentWidgets: [],
-        answeredPages: []
+        answeredPages: [],
+        facetteBehaviours: []
     }),
     actions: {
         __i(key: string) {
@@ -88,6 +90,11 @@ export const useSessionStore = defineStore('websiteStore', {
                 const oldPageNumber = this.currentPage.id;
                 this.selectPage(oldPageNumber);
             }
+        },
+        async updateBehaviours() {
+            this.facetteBehaviours = await sessionApi.sessionFacettebehaviourList({
+                sessionPk: this.session.resultId
+            });
         },
         async updateSession(sessionVersion: number)  {
             this.session = await sessionApi.sessionPartialUpdate({

--- a/code/frontend/states/session.ts
+++ b/code/frontend/states/session.ts
@@ -84,8 +84,10 @@ export const useSessionStore = defineStore('websiteStore', {
             this.pages = await sessionApi.sessionPageList({
                 sessionPk: this.session.resultId
             })
-            const oldPageNumber = this.currentPage.id;
-            this.selectPage(oldPageNumber);
+            if (this.currentPage) {
+                const oldPageNumber = this.currentPage.id;
+                this.selectPage(oldPageNumber);
+            }
         },
         async updateSession(sessionVersion: number)  {
             this.session = await sessionApi.sessionPartialUpdate({

--- a/code/kuusi/kuusi/settings.py
+++ b/code/kuusi/kuusi/settings.py
@@ -218,6 +218,8 @@ RTL_LANGUAGES = [
     "he"
 ]
 
+FRONTEND_URL = "http://localhost:3000"
+
 TIME_ZONE = "UTC"
 
 USE_I18N = False

--- a/code/kuusi/kuusi/urls.py
+++ b/code/kuusi/kuusi/urls.py
@@ -34,6 +34,7 @@ from web.rest.page import PageViewSet
 from web.rest.session import SessionViewSet
 from web.rest.category import CategoryViewSet
 from web.rest.facetteselection import FacetteSelectionViewSet
+from web.rest.facetteehaviour import FacetteBehaviourViewSet
 from web.rest.widget import WidgetViewSet
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
@@ -65,6 +66,7 @@ router_page.register(r"widget", WidgetViewSet, basename="widget-page")
 router_sessions.register(r'facette', FacetteViewSet, basename='session-facettes')
 router_sessions.register(r'category', CategoryViewSet, basename='session-categories')
 router_sessions.register(r'facetteselection', FacetteSelectionViewSet, basename='session-selections')
+router_sessions.register(r'facettebehaviour', FacetteBehaviourViewSet, basename='session-behaviour')
 
 
 urlpatterns = [

--- a/code/kuusi/kuusi/urls.py
+++ b/code/kuusi/kuusi/urls.py
@@ -34,7 +34,7 @@ from web.rest.page import PageViewSet
 from web.rest.session import SessionViewSet
 from web.rest.category import CategoryViewSet
 from web.rest.facetteselection import FacetteSelectionViewSet
-from web.rest.facetteehaviour import FacetteBehaviourViewSet
+from web.rest.facettebehaviour import FacetteBehaviourViewSet
 from web.rest.widget import WidgetViewSet
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 

--- a/code/kuusi/web/rest/facettebehaviour.py
+++ b/code/kuusi/web/rest/facettebehaviour.py
@@ -34,7 +34,7 @@ from typing import List
 class FacetteBehaviourSerializer(serializers.ModelSerializer):
     class Meta:
         model = FacetteBehaviour
-        fields = ('description', 'criticality')
+        fields = ('description', 'criticality', 'affected_objects', 'affected_subjects', )
     
     
 class FacetteBehaviourViewSet(ListModelMixin, GenericViewSet):

--- a/code/kuusi/web/rest/facettebehaviour.py
+++ b/code/kuusi/web/rest/facettebehaviour.py
@@ -1,0 +1,74 @@
+"""
+kuusi
+Copyright (C) 2014-2024  Christoph Müller  <mail@chmr.eu>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+
+from web.models import FacetteSelection, Session, Facette, FacetteBehaviour
+from rest_framework import serializers
+from drf_spectacular.utils import  extend_schema, OpenApiResponse
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema, OpenApiResponse
+from rest_framework import status
+from kuusi.settings import LANGUAGE_CODES
+from rest_framework.viewsets import GenericViewSet
+from rest_framework.mixins import ListModelMixin, DestroyModelMixin
+from rest_framework.response import Response
+from django.db.models import Q
+
+from typing import List
+
+class FacetteBehaviourSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = FacetteBehaviour
+        fields = ('description', 'criticality')
+    
+    
+class FacetteBehaviourViewSet(ListModelMixin, GenericViewSet):
+    queryset = FacetteSelection.objects.all()
+    serializer_class = FacetteBehaviourSerializer
+    @extend_schema(
+        responses={
+            status.HTTP_200_OK: OpenApiResponse(response=FacetteBehaviourSerializer, description="The list of active facette behaviour objects"),
+        },
+        parameters=[ 
+          OpenApiParameter("session_pk", OpenApiTypes.STR, OpenApiParameter.PATH, required=True),
+        ],
+    )
+    def list(self, request,  *args, **kwargs):    
+        session: Session = Session.objects.filter(result_id=kwargs["session_pk"]).first()
+        active_facette_selections = FacetteSelection.objects.filter(session=session)
+        results = []
+        for active_facette_selection in active_facette_selections:
+            facette = active_facette_selection.facette
+            behaviours = FacetteBehaviour.objects.filter(
+                Q(affected_subjects__pk__in=[facette.pk])|
+                Q(affected_objects__pk__in=[facette.pk])
+            )
+            # TODO: Identify others
+            behaviour: FacetteBehaviour
+            for behaviour in behaviours:
+                result = behaviour.is_true(facette, [])
+                if result:
+                    results.append(behaviour)
+
+        serializer = FacetteBehaviourSerializer(
+            results,
+            many=True
+        )
+        serializer.context["session_pk"] = kwargs["session_pk"]
+        return Response(serializer.data)
+    


### PR DESCRIPTION
Introduce a RESTful API with OpenAPI 3 specification.

Continuation of #342 and #345 to prevent gigantic PR.

Requirement for client side frontend.

- [x] Setup session
- [x] Change language
- [x] Change version
- [x] Navigate, skip
- [x] Change page
- [x] Answer facettes
- [x] Compute behaviour
- [x] Display behaviour
- [x] Weight facettes
- [x] Compute results
- [ ] Add architectural documentation
- [ ] License headers!
- [x] Show results
- [ ] Show interested users where a facette comes from and what the results are (feedback mode light)
- [ ] Clone another session as starting point
- [x] Inject language values into frontend
- [ ] Decide what to do with HTMLWidget (no HTML injection desired on client)