### PR TITLE
Add session cloning

### DIFF
--- a/code/frontend/components/Category.vue
+++ b/code/frontend/components/Category.vue
@@ -19,6 +19,6 @@ interface CategoryProps {
 const props = defineProps<CategoryProps>();
 const store = useSessionStore();
 const isAnswered = computed(() => {
-  return store.answeredPages.indexOf(props.category.targetPage) != -1;
+  return store.facetteSelections.filter(l => l.pagesOfFacettes.indexOf(props.category.targetPage) != -1).length > 0
 });
 </script>

--- a/code/frontend/pages/[[lang]]/[[resultId]].vue
+++ b/code/frontend/pages/[[lang]]/[[resultId]].vue
@@ -26,7 +26,7 @@ if (lang == "") {
     replace: true
   })
 }
-const id: string | null = (router.params.id as string) ?? null;
+const id: string | null = (router.params.resultId as string) ?? null;
 
 const sessionStore = useSessionStore();
 onMounted(async () => {

--- a/code/frontend/states/session.ts
+++ b/code/frontend/states/session.ts
@@ -8,7 +8,6 @@ interface SessionState {
     currentPage: Page | null;
     facetteSelections: FacetteSelection[];
     currentWidgets: MetaWidget[];
-    answeredPages: number[],
     facetteBehaviours: FacetteBehaviour[]
 }
 
@@ -29,7 +28,6 @@ export const useSessionStore = defineStore('websiteStore', {
         currentPage: null,
         facetteSelections: [],
         currentWidgets: [],
-        answeredPages: [],
         facetteBehaviours: []
     }),
     actions: {
@@ -47,9 +45,6 @@ export const useSessionStore = defineStore('websiteStore', {
                     },
                     reset: reset
                 });
-                if (this.answeredPages.indexOf(currentPageId) == -1){
-                    this.answeredPages.push(currentPageId)
-                }
             } else {
                 await this.deleteFacetteSelection(id, currentPageId);
             }
@@ -63,7 +58,6 @@ export const useSessionStore = defineStore('websiteStore', {
                 id: selection.id,
                 sessionPk: this.session.resultId
             });
-            this.answeredPages = this.answeredPages.filter(s => s != currentPageId)
         },
         async createSession(lang: string, resultId?: string) {
             this.session = await sessionApi.sessionCreate(

--- a/code/frontend/states/session.ts
+++ b/code/frontend/states/session.ts
@@ -77,6 +77,12 @@ export const useSessionStore = defineStore('websiteStore', {
                 /** Select the first available page, if any */
                 this.selectPage(-1)
             }
+            // if there was a resultId given -> update selections from it
+            if (resultId) {
+                this.facetteSelections = await sessionApi.sessionFacetteselectionList({
+                    sessionPk: this.session.resultId
+                })
+            }
         },
         async updateCategoriesAndPages() {
             this.categories = await sessionApi.sessionCategoryList({

--- a/code/kuusi/kuusi/urls.py
+++ b/code/kuusi/kuusi/urls.py
@@ -37,7 +37,6 @@ from web.rest.facetteselection import FacetteSelectionViewSet
 from web.rest.facettebehaviour import FacetteBehaviourViewSet
 from web.rest.widget import WidgetViewSet
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
-
 from kuusi.settings import STATIC_URL, STATIC_ROOT
 
 dynamic_routes = [   


### PR DESCRIPTION
Introduce a RESTful API with OpenAPI 3 specification and client.

Continuation of #342, #345, #346 to prevent gigantic PR.

- [x] Setup session
- [x] Change language
- [x] Change version
- [x] Navigate, skip
- [x] Change page
- [x] Answer facettes
- [x] Compute behaviour
- [x] Display behaviour
- [x] Weight facettes
- [x] Compute results
- [ ] Add architectural documentation
- [ ] License headers!
- [x] Show results
- [ ] Show interested users where a facette comes from and what the results are (feedback mode light)
- [x] Clone another session as starting point
- [x] Inject language values into frontend
- [ ] Decide what to do with HTMLWidget (no HTML injection desired on client)