### PR TITLE
UX skeleton

### DIFF
--- a/code/frontend/components/Categories.vue
+++ b/code/frontend/components/Categories.vue
@@ -1,7 +1,7 @@
 <template>
-  <div> 
+   <ul class="nav nav-pills row">
     <Category  v-for="(category, index) in categories"   v-bind:key="index" :category="category" />
-  </div>
+   </ul>
 </template>
   <script lang="ts" setup>
 import { useSessionStore } from "~/states/session";

--- a/code/frontend/components/Category.vue
+++ b/code/frontend/components/Category.vue
@@ -1,12 +1,14 @@
 
 
 <template>
-  <div
+  <li
     v-if="props.category.targetPage"
     v-on:click="store.selectPage(props.category.targetPage)"
+    class="col col-3 nav-item"
   >
-    {{ props.category.name }} {{ isAnswered }}
-  </div>
+    
+    <a :class="'nav-link ' + (isCurrent ? 'active' : '')" aria-current="page" href="#">{{ props.category.name }} </a>
+</li>
 </template>
     <script lang="ts" setup>
 import { Category } from "~/sdk/models";
@@ -21,4 +23,7 @@ const store = useSessionStore();
 const isAnswered = computed(() => {
   return store.facetteSelections.filter(l => l.pagesOfFacettes.indexOf(props.category.targetPage) != -1).length > 0
 });
+const isCurrent = computed(() => {
+  return store.currentPage != null && store.currentPage.id == props.category.targetPage
+})
 </script>

--- a/code/frontend/components/RenderField.vue
+++ b/code/frontend/components/RenderField.vue
@@ -3,7 +3,7 @@
     <div v-if="store.currentPage">
       {{ store.currentPage.text }}
       {{ store.currentPage.help }}
-      <div v-for="row in 12" :key="row" class="grid gap-4">
+      <div v-for="row in 12" :key="row" class="row">
         <WidgetsWrapper :row="row" />
       </div>
     </div>

--- a/code/frontend/components/WidgetsWrapper.vue
+++ b/code/frontend/components/WidgetsWrapper.vue
@@ -3,7 +3,7 @@
     <div
       v-for="(widget, index) in store.currentWidgets.filter((w ) => w.row == props.row)"
       :key="index"
-      :class="'col-' + widget.width"
+      :class="'col col-' + widget.width"
     >
     <NavigationWidget v-if="widget.widgetType == 'NavigationWidget'" :widget="widget"/>
     <FacetteSelectionWidget v-if="widget.widgetType == 'FacetteSelectionWidget'" :checkbox="true" :widget="widget"/>

--- a/code/frontend/components/widgets/FacetteSelectionWidget.vue
+++ b/code/frontend/components/widgets/FacetteSelectionWidget.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    {{ props.widget.facettes  }}
     <Behaviour v-for="(facette, index) in props.widget.facettes" v-bind:key="index"  :facette="facette"/>
     <div v-for="(facette, index) in props.widget.facettes" v-bind:key="index">
       <Facette :facette="facette" :checkbox="props.checkbox"/>

--- a/code/frontend/components/widgets/NavigationWidget.vue
+++ b/code/frontend/components/widgets/NavigationWidget.vue
@@ -1,8 +1,20 @@
 <template>
-  <div>
-    <a v-if="canGoBack" href="#" v-on:click="goBack">{{  store.__i("BTN_PREV_PAGE") }}</a>
-    <a v-if="canGoNext" href="#" v-on:click="goNext"> {{  store.__i("BTN_SKIP_PAGE") }} </a>
-    <a v-if="canGoNext" href="#" v-on:click="goNext"> {{  store.__i("BTN_NEXT_PAGE") }} </a>
+  <div class="row">
+    <div class="col">
+      <a v-if="canGoBack" href="#" v-on:click="goBack">{{
+        store.__i("BTN_PREV_PAGE")
+      }}</a>
+    </div>
+    <div class="col">
+      <a v-if="canGoNext" href="#" v-on:click="goNext">
+        {{ store.__i("BTN_SKIP_PAGE") }}
+      </a>
+    </div>
+    <div class="col">
+      <a v-if="canGoNext" href="#" v-on:click="goNext">
+        {{ store.__i("BTN_NEXT_PAGE") }}
+      </a>
+    </div>
   </div>
 </template>
 <script setup lang="ts">
@@ -24,10 +36,12 @@ const canGoBack = computed(() => {
 });
 const goBack = () =>
   store.selectPage(
-    store.pages[store.pages.findIndex((p) => p.id == store.currentPage.id) - 1].id
+    store.pages[store.pages.findIndex((p) => p.id == store.currentPage.id) - 1]
+      .id
   );
 const goNext = () =>
   store.selectPage(
-    store.pages[store.pages.findIndex((p) => p.id == store.currentPage.id) +1].id
+    store.pages[store.pages.findIndex((p) => p.id == store.currentPage.id) + 1]
+      .id
   );
 </script>

--- a/code/frontend/components/widgets/facettes/Assignment.vue
+++ b/code/frontend/components/widgets/facettes/Assignment.vue
@@ -1,0 +1,12 @@
+<template>
+    <div>{{ assignment }}</div>
+  </template>
+  <script setup lang="ts">
+  import type { FacetteAssignment } from "~/sdk";
+  
+  interface AsssignmentProps {
+    assignment: FacetteAssignment;
+  }
+
+const props = defineProps<AsssignmentProps>();
+  </script>

--- a/code/frontend/components/widgets/facettes/Facette.vue
+++ b/code/frontend/components/widgets/facettes/Facette.vue
@@ -20,8 +20,13 @@
       />
       {{ props.facette.selectableDescription }} {{  isSelected }}
     </div>
+    <a href="#" v-on:click="toggleExpand">Why</a>
+    <div v-if="isExpanded.valueOf()">
+      <div v-for="key, index in props.facette.assignments" :key="index">
+        <Assignment :assignment="key"/>
+      </div>
+    </div>
     <div>
-
       <input v-if="isSelected" type="range" v-model="weight" min="-2" max="2" step="1" v-on:change="registerWeightChange"/> 
     </div>
   </div>
@@ -31,6 +36,7 @@ import { useState } from "nuxt/app";
 import { onMounted, ref } from "vue";
 import { SessionApi, type Facette } from "~/sdk";
 import { apiConfig, useSessionStore } from "../../../states/session";
+import Assignment from "./Assignment.vue";
 
 interface CheckboxFacetteProps {
   facette: Facette;
@@ -40,13 +46,15 @@ interface CheckboxFacetteProps {
 const props = defineProps<CheckboxFacetteProps>();
 const store = useSessionStore();
 const selected = useState(
-  props.facette.id.toString(),
+  props.facette.id.toString() + "_selected",
   () =>
     store.facetteSelections.filter((l) => l.facette == props.facette.id)
       .length != 0
 );
 
 const weight = ref(0)
+const isExpanded = useState(props.facette.id.toString() + "_expanded", () => false)
+const toggleExpand = () => isExpanded.value = !isExpanded.value
 
 const isSelected = computed(() => store.facetteSelections.filter((l) => l.facette == props.facette.id).length !=0);
 

--- a/code/frontend/nuxt.config.ts
+++ b/code/frontend/nuxt.config.ts
@@ -3,7 +3,7 @@ export default defineNuxtConfig({
   compatibilityDate: '2024-11-01',
   devtools: { enabled: true },
   modules: [
-    '@pinia/nuxt',
-    '@nuxtjs/tailwindcss'
-  ]
+    '@pinia/nuxt'
+  ],
+  css: ["bootstrap/dist/css/bootstrap.min.css"]
 })

--- a/code/frontend/package.json
+++ b/code/frontend/package.json
@@ -12,13 +12,11 @@
   "dependencies": {
     "@openapitools/openapi-generator-cli": "^2.15.3",
     "@pinia/nuxt": "^0.9.0",
+    "bootstrap": "^5.3.3",
     "nuxt": "^3.14.1592",
     "pinia": "^2.3.0",
     "vue": "latest",
     "vue-router": "latest"
   },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
-  "devDependencies": {
-    "@nuxtjs/tailwindcss": "^6.12.2"
-  }
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/code/frontend/pages/[[lang]]/[[resultId]].vue
+++ b/code/frontend/pages/[[lang]]/[[resultId]].vue
@@ -1,15 +1,24 @@
 <template>
   <div>
     <NuxtRouteAnnouncer />
-    <div class="grid grid-cols-12 gap-3">
-      <div class="col-span-2 bg-blue-100">
-        <Language v-if="sessionStore.session"/>
-        <Categories />
+    <main role="main" class="container">
+      <div class="text-center">
+        <div class="row">
+          <div class="col col-2">
+            <img class="mt-2" src="https://distrochooser.de/logo.min.svg" />
+          </div>
+          <div class="col">
+            <Categories />
+          </div>
+          <div class="col col-2">
+            <Language v-if="sessionStore.session" />
+          </div>
+        </div>
       </div>
-      <div class="col-span-10 bg-red-100">
+      <div class="page mt-1">
         <RenderField />
       </div>
-    </div>
+    </main>
   </div>
 </template>
 <script lang="ts" setup>
@@ -19,12 +28,12 @@ import { useRoute } from "vue-router";
 import { useSessionStore } from "~/states/session";
 
 const router = useRoute();
-const lang: string = (router.params.lang as string);
+const lang: string = router.params.lang as string;
 if (lang == "") {
-   navigateTo("/en", {
+  navigateTo("/en", {
     redirectCode: 301,
-    replace: true
-  })
+    replace: true,
+  });
 }
 const id: string | null = (router.params.resultId as string) ?? null;
 

--- a/code/frontend/states/session.ts
+++ b/code/frontend/states/session.ts
@@ -11,6 +11,7 @@ interface SessionState {
     facetteBehaviours: FacetteBehaviour[]
 }
 
+
 // TODO: Move this out of this sourcecode
 export const apiConfig = new Configuration({
     basePath: "http://localhost:8000",

--- a/code/frontend/yarn.lock
+++ b/code/frontend/yarn.lock
@@ -1768,6 +1768,11 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
+bootstrap@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.3.tgz#de35e1a765c897ac940021900fcbb831602bac38"
+  integrity sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"

--- a/code/kuusi/web/rest/facette.py
+++ b/code/kuusi/web/rest/facette.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 
-from web.models import Facette, Session
+from web.models import Facette, Session, FacetteAssignment
 from rest_framework import serializers
 from drf_spectacular.utils import  extend_schema, OpenApiResponse
 from drf_spectacular.types import OpenApiTypes
@@ -27,18 +27,32 @@ from kuusi.settings import LANGUAGE_CODES
 from rest_framework.viewsets import GenericViewSet
 from rest_framework.mixins import ListModelMixin
 from rest_framework.response import Response
+from drf_spectacular.utils import extend_schema_field
 
+from typing import Dict, Any, List
 
-from typing import Dict, Any
+class FacetteAssignmentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = FacetteAssignment
+        fields = ('id', 'choosables', 'catalogue_id', 'long_description', 'assignment_type', )
 
 class FacetteSerializer(serializers.ModelSerializer):
     selectable_description = serializers.SerializerMethodField()
+    assignments = serializers.SerializerMethodField()
     class Meta:
         model = Facette
-        fields = ('id', 'topic', 'selectable_description')
+        fields = ('id', 'topic', 'selectable_description', 'assignments')
     def get_selectable_description(self, obj: Facette) -> str:
         session: Session = Session.objects.filter(result_id=self.context['session_pk']).first()
         return obj.__("selectable_description",  session.language_code)
+    
+    @extend_schema_field(field=FacetteAssignmentSerializer(many=True))
+    def get_assignments(self, obj:Facette) -> List[FacetteAssignment]:
+        serializer = FacetteAssignmentSerializer(
+            FacetteAssignment.objects.filter(facettes__in=[obj]),
+            many=True
+        )
+        return serializer.data
     
     
 class FacetteViewSet(ListModelMixin, GenericViewSet):

--- a/code/kuusi/web/rest/facette.py
+++ b/code/kuusi/web/rest/facette.py
@@ -17,7 +17,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 
-from web.models import Facette, Session, FacetteAssignment
+from web.models import Facette, Session, FacetteAssignment, Choosable
+from web.rest.choosable import ChoosableSerializer
 from rest_framework import serializers
 from drf_spectacular.utils import  extend_schema, OpenApiResponse
 from drf_spectacular.types import OpenApiTypes
@@ -41,7 +42,7 @@ class FacetteSerializer(serializers.ModelSerializer):
     assignments = serializers.SerializerMethodField()
     class Meta:
         model = Facette
-        fields = ('id', 'topic', 'selectable_description', 'assignments')
+        fields = ('id', 'topic', 'selectable_description', 'assignments',)
     def get_selectable_description(self, obj: Facette) -> str:
         session: Session = Session.objects.filter(result_id=self.context['session_pk']).first()
         return obj.__("selectable_description",  session.language_code)


### PR DESCRIPTION
Introduce a RESTful API with OpenAPI 3 specification and client.

Continuation of #342, #345, #346, #347 to prevent gigantic PR.

- [x] Setup session
- [x] Change language
- [x] Change version
- [x] Navigate, skip
- [x] Change page
- [x] Answer facettes
- [x] Compute behaviour
- [x] Display behaviour
- [x] Weight facettes
- [x] Compute results
- [ ] Add architectural documentation
- [ ] License headers!
- [x] Show results
- [x] Show interested users where a facette comes from and what the results are (feedback mode light)
- [x] Clone another session as starting point
- [x] Inject language values into frontend
- [ ] Decide what to do with HTMLWidget (no HTML injection desired on client)